### PR TITLE
Demonstrate workaround PEX

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -24,14 +24,9 @@ jobs:
         run: |-
           curl --proto '=https' --tlsv1.2 -fsSL https://static.pantsbuild.org/setup/get-pants.sh | bash
 
-      - name: Pants Check
-        run: |
-          pants tailor --check ::
-          pants update-build-files --check ::
-
-      - name: Test
+      - name: Seed cache first
         run: |-
-          pants test ::
+          pants --no-local-cache package :__workaround_pex_issue_2395
 
       - name: Package
         run: |

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,8 @@
+# FIXME https://github.com/pex-tool/pex/issues/2395: we need to pre-seed the pex_root named cache
+# with these dependencies before building for other platforms
+pex_binary(
+    name="__workaround_pex_issue_2395",
+    dependencies=["3rdparty/python:reqs#pbipy"],
+    # this PEX isn't for anything, so let's choose options that make it most efficient to build
+    layout="packed"
+)


### PR DESCRIPTION
When I run locally

```shell
dir=$(mktemp -d)

# fails!
pants --no-local-cache --named-caches-dir=$dir package project/src/python/hello/:bin

# seed the cache
pants --no-local-cache --named-caches-dir=$dir package :__workaround_pex_issue_2395

# works now
pants --no-local-cache --named-caches-dir=$dir package project/src/python/hello/:bin
```